### PR TITLE
doc: fix LICENSE detection

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -3,9 +3,30 @@ The Clear BSD License
 Copyright (c) 2012-2020 ARM Limited
 All rights reserved.
 
-Redistribution and use in source and binary forms, with or without modification, are permitted (subject to the limitations in the disclaimer below) provided that the following conditions are met:
+Redistribution and use in source and binary forms, with or without
+modification, are permitted (subject to the limitations in the disclaimer
+below) provided that the following conditions are met:
 
-* Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
-* Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
-* Neither the name of ARM Limited nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
-NO EXPRESS OR IMPLIED LICENSES TO ANY PARTY'S PATENT RIGHTS ARE GRANTED BY THIS LICENSE. THIS SOFTWARE IS PROVIDED BY ARM Limited "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL ARM Limited BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+     * Redistributions of source code must retain the above copyright notice,
+     this list of conditions and the following disclaimer.
+
+     * Redistributions in binary form must reproduce the above copyright
+     notice, this list of conditions and the following disclaimer in the
+     documentation and/or other materials provided with the distribution.
+
+     * Neither the name of the copyright holder nor the names of its
+     contributors may be used to endorse or promote products derived from this
+     software without specific prior written permission.
+
+NO EXPRESS OR IMPLIED LICENSES TO ANY PARTY'S PATENT RIGHTS ARE GRANTED BY
+THIS LICENSE. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER
+IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.


### PR DESCRIPTION
Licenses are detected by https://github.com/licensee/licensee
Canonical license text in https://choosealicense.com/licenses/bsd-3-clause-clear/
Working Clear-BSD repos in https://github.com/search?q=license%3Absd-3-clause-clear&type=Repositories&ref=advsearch&l=&l= 

You can test this by installing it and running "licensee detect" on "master" and "fix/5", here is the output:

"master"

License:        NOASSERTION
Matched files:  LICENSE, README.md
LICENSE:
  Content hash:  25f2dde348dfb3940ca3b35542c94ed671793492
  License:       NOASSERTION
  Closest non-matching licenses:
    BSD-3-Clause-Clear similarity:  96.50%
    BSD-3-Clause similarity:        92.00%
    BSD-4-Clause similarity:        90.91%
README.md:
  Content hash:  962521a6b908b623479c3893cf4e271e48e3bf9d
  Confidence:    90.00%
  Matcher:       Licensee::Matchers::Reference
  License:       BSD-3-Clause-Clear
  Closest non-matching licenses:
    WTFPL similarity:      11.27%
    0BSD similarity:       4.76%
    Unlicense similarity:  4.48%

"fix/5"

License:        BSD-3-Clause-Clear
Matched files:  LICENSE, README.md
LICENSE:
  Content hash:  251d4599b622d2a87b2c4bb21dfacd438c048466
  Attribution:   Copyright (c) 2012-2020 ARM Limited
  Confidence:    100.00%
  Matcher:       Licensee::Matchers::Exact
  License:       BSD-3-Clause-Clear
README.md:
  Content hash:  962521a6b908b623479c3893cf4e271e48e3bf9d
  Confidence:    90.00%
  Matcher:       Licensee::Matchers::Reference
  License:       BSD-3-Clause-Clear
  Closest non-matching licenses:
    WTFPL similarity:      11.27%
    0BSD similarity:       4.76%
    Unlicense similarity:  4.48%