### PR TITLE
Enhanced Randomness through Seeding

### DIFF
--- a/proto/tp_config.proto
+++ b/proto/tp_config.proto
@@ -53,6 +53,10 @@ message RandomDesc {
     optional PoissonDesc poisson_desc = 11;
     // Weibull random number descriptor
     optional WeibullDesc weibull_desc = 12;
+
+    // Force seed on Mersenne-Twist 64bit
+    optional uint64 seed = 13 [default = 0];
+
 }
 
 message PatternConfiguration {

--- a/random_generator.cc
+++ b/random_generator.cc
@@ -20,7 +20,8 @@ Generator::Generator(const uint64_t s):
         type(RandomDesc::UNIFORM),
         distribution(nullptr),
         seed(s) {
-    mersenne.seed(seed);
+    this->seed = rd();
+    mersenne.seed(this->seed);
 }
 
 Generator::~Generator() {
@@ -28,7 +29,13 @@ Generator::~Generator() {
 }
 
 void Generator::init(const RandomDesc::Type t,
-        const uint64_t base, const uint64_t range) {
+        const uint64_t base, const uint64_t range, const uint64_t seed) {
+    // specified seed setup   
+    if(seed != 0){
+        mersenne.seed(seed);
+        this->seed = seed;
+    }
+
     // clean previously allocated generators
     delete distribution;
     // set new type
@@ -62,10 +69,16 @@ void Generator::init(const RandomDesc::Type t,
     initialized = true;
 }
 
-void Generator::init(const RandomDesc& from) {
+void Generator::init(const RandomDesc& from, const uint64_t seed) {
 
     // clean previously allocated generators
     delete distribution;
+    
+    // specified seed setup
+    if(seed != 0){
+        mersenne.seed(seed);
+        this->seed = seed;
+    }
 
     type = from.type();
 
@@ -103,6 +116,17 @@ uint64_t Generator::get() {
         LOG("Generator::get generated",RandomDesc::Type_Name(type),"value", ret);
     } else {
         ERROR("RandomGenerator::get uninitialised");
+    }
+    return ret;
+}
+
+uint64_t Generator::getSeed() {
+    uint64_t ret = 0;
+    if(initialized){
+        ret = this->seed;
+        LOG("Generator::getSeed generated",ret,"value");
+    } else {
+        ERROR("RandomGenerator::getSeed uninitialised");
     }
     return ret;
 }

--- a/random_generator.hh
+++ b/random_generator.hh
@@ -203,6 +203,8 @@ public:
  * Uses the default generator defined in the random C++11 library
  */
 class Generator {
+    //! Platform specific RNG that generates the seed of the Mersenne Twister 64-bit
+    random_device rd;
 
     //! Mersenne Twister 64-bit random generator
     mt19937_64 mersenne;
@@ -238,22 +240,30 @@ class Generator {
     /*!
      * Initialises a Random Generator Descriptor with data from a configuration object
      *\param from the Google Protocol Buffer configuration object
+     *\param seed seed for the Mersenne Twist 64-bit
      */
-    void init(const RandomDesc&);
+    void init(const RandomDesc&, const uint64_t = 0);
 
     /*!
      * Initialises a Random Generator Descriptor with a base and a range value
      *\param t random distribution type
      *\param base minimum value
      *\param range max deviation from min value (max=base+range)
+     *\param seed seed for the Mersenne Twist 64-bit
      */
-    void init(const RandomDesc::Type, const uint64_t, const uint64_t);
+    void init(const RandomDesc::Type, const uint64_t, const uint64_t, const uint64_t = 0);
 
     /*!
      * Gets a new value from the configured distribution
      *\return a randomly extracted unsigned integer value
      */
     uint64_t get();
+
+    /*!
+     * Gets the seed value
+     *\return the seed of the Mersenne Twist
+     */
+    uint64_t getSeed();
 
     /*!
      * Returns the configured random generator type


### PR DESCRIPTION
Made modifications to the files to infuse seed-based randomness into the Mersenne Twister algorithm, enhancing the random address functionality. A new parameter, ‘seed’, has been introduced in .atp files. In the absence of an explicitly set seed, ATP will autonomously generate an initial random seed using the random_device() function. However, if a seed is specified, it will be relayed to the random_generator class. This ‘seed’ parameter can be incorporated within the “RandomDesc” message. Given that “RandomDesc” is utilized for both Sizes and Addresses, it can be employed for either one, both, or none of them.